### PR TITLE
*: specify timezone per query

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "rxjs": "6.6.3"
   },
   "dependencies": {
+    "moment-timezone": "^0.5.34",
     "tslib": "^2.3.0"
   }
 }

--- a/src/components/FieldEditor.tsx
+++ b/src/components/FieldEditor.tsx
@@ -4,6 +4,7 @@ import defaults from 'lodash/defaults';
 import React, { FormEvent, useState } from 'react';
 import { CSVQuery, defaultQuery, FieldSchema } from '../types';
 import { SchemaEditor } from './SchemaEditor';
+import momentTz from 'moment-timezone';
 
 interface Props {
   query: CSVQuery;
@@ -14,7 +15,10 @@ interface Props {
 }
 
 export const FieldEditor = ({ query, onChange, onRunQuery, limit, editorContext }: Props) => {
-  const { header, skipRows, delimiter, decimalSeparator, ignoreUnknown, schema } = defaults(query, defaultQuery);
+  const { header, skipRows, delimiter, decimalSeparator, ignoreUnknown, schema, timezone } = defaults(
+    query,
+    defaultQuery
+  );
 
   const [numSkipRows, setNumSkipRows] = useState(skipRows?.toString());
 
@@ -23,6 +27,13 @@ export const FieldEditor = ({ query, onChange, onRunQuery, limit, editorContext 
     { label: 'Semicolon', value: ';' },
     { label: 'Tab', value: '\t' },
   ];
+
+  const tzData = momentTz.tz.names().map((s: string) => ({ label: s, value: s }));
+
+  const onTzChange = (value: SelectableValue<string>) => {
+    onChange({ ...query, timezone: value.value ?? 'UTC' });
+    onRunQuery();
+  };
 
   const onDelimiterChange = (value: SelectableValue<string>) => {
     onChange({ ...query, delimiter: value.value ?? ',' });
@@ -103,7 +114,11 @@ export const FieldEditor = ({ query, onChange, onRunQuery, limit, editorContext 
         >
           <InlineSwitchFallback value={ignoreUnknown} onChange={onIgnoreUnknownChange} />
         </InlineField>
+        <InlineField label="Timezone" tooltip="Timezone timestamps without explicit Zone are parsed in">
+          <Select width={20} value={tzData.find((_) => _.value === timezone)} onChange={onTzChange} options={tzData} />
+        </InlineField>
       </InlineFieldRow>
+
       <SchemaEditor value={schema} onChange={onSchemaChange} limit={limit} />
     </>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface CSVQuery extends DataQuery {
   header: boolean;
   ignoreUnknown: boolean;
   skipRows: number;
+  timezone: string;
   decimalSeparator: string;
 
   method: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8360,6 +8360,13 @@ moment-timezone@0.5.33:
   dependencies:
     moment ">= 2.9.0"
 
+moment-timezone@^0.5.34:
+  version "0.5.34"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.34.tgz#a75938f7476b88f155d3504a9343f7519d9a405c"
+  integrity sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==
+  dependencies:
+    moment ">= 2.9.0"
+
 moment@2.29.1, moment@2.x, "moment@>= 2.9.0":
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"


### PR DESCRIPTION
Adds a field to the query UI to specify the timezone of all time fields
in the data.

Timezone parsing is done using `time.ParseInLocation`.

Fixes https://github.com/marcusolsson/grafana-csv-datasource/discussions/189