### PR TITLE
csvqueryfield: simpler field update

### DIFF
--- a/.changeset/giant-years-film.md
+++ b/.changeset/giant-years-film.md
@@ -1,0 +1,5 @@
+---
+'grafana-csv-datasource': patch
+---
+
+🐛 **Fix**: Consistently apply field names

--- a/src/components/CSVQueryField.tsx
+++ b/src/components/CSVQueryField.tsx
@@ -1,6 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 import { InlineField, QueryField, Select } from '@grafana/ui';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { FieldSchema } from 'types';
 
 interface Props {
@@ -9,13 +9,9 @@ interface Props {
 }
 
 export const CSVQueryField = ({ field, onFieldChange }: Props) => {
-  const [name, setName] = useState(field.name);
-
-  useEffect(() => {
-    setName(field.name);
-  }, [field]);
-
-  const onNameChange = (value: string) => setName(value);
+  const onNameChange = (value: string) => {
+    onFieldChange({ ...field, name: value });
+  };
   const onTypeChange = (selectableValue: SelectableValue<string>) => {
     onFieldChange({ ...field, type: selectableValue.value! });
   };
@@ -23,12 +19,7 @@ export const CSVQueryField = ({ field, onFieldChange }: Props) => {
   return (
     <>
       <InlineField label="Field" tooltip={`Name of the CSV column to include.`} grow>
-        <QueryField
-          query={name}
-          onRunQuery={() => onFieldChange({ ...field, name })}
-          onChange={onNameChange}
-          portalOrigin="csv"
-        />
+        <QueryField query={field.name} onChange={onNameChange} portalOrigin="csv" />
       </InlineField>
       <InlineField label="Type" tooltip="Set the type of a field. By default, all fields have type String.">
         <Select


### PR DESCRIPTION
simplified on-change handling. this will fix the problem where changing the json-schema-field-name does not get applied.

how to test:
1. use the csv plugin
2. enable the browser devtools
3. enter a field name
4. run the query
5. verify in the dev-tools, that in the outgoing ajax request, the field-name is correct in the JSON structure
6. enable the "ignore unknown" toggle
7. run the query again
8. verify that you can see the column