### PR TITLE
fix running the plugin in grafana 9.5.x and 10.0.x

### DIFF
--- a/src/components/CSVQueryField.tsx
+++ b/src/components/CSVQueryField.tsx
@@ -19,7 +19,16 @@ export const CSVQueryField = ({ field, onFieldChange }: Props) => {
   return (
     <>
       <InlineField label="Field" tooltip={`Name of the CSV column to include.`} grow>
-        <QueryField query={field.name} onChange={onNameChange} portalOrigin="csv" />
+        <QueryField
+          query={field.name}
+          onChange={onNameChange}
+          portalOrigin="csv"
+          // https://github.com/grafana/grafana/commit/f6d3a5cc9411acf20c9a8a497c993667aa825062
+          // auto-adds the `onblur: empty-function` prop,
+          // but for older grafana versions we need to add this.
+          // we can remove this when we stop supporting grafana versions before that commit.
+          onBlur={() => {}}
+        />
       </InlineField>
       <InlineField label="Type" tooltip="Set the type of a field. By default, all fields have type String.">
         <Select


### PR DESCRIPTION
since https://github.com/grafana/grafana/pull/69487 grafana-ui's `query-field` auto-applies an empty `onBlur: () => {}` prop, if it is not provided.

but, for older grafana-versions, this does not happen, so we need to do it, otherwise the query-field does not work properly.
also, it does not hurt even in newer grafana versions, so we just do it always.

how to test:
1. setup the plugin, use the URL from here: https://github.com/grafana/grafana-csv-datasource/blob/4c75a35e7e1a0be825dd748dea58f1654d85bb23/provisioning/datasources/datasource.yaml#L7
2. go to explore, and configure two fields:
    - date: type=time
    - price: type=number
3. verify that you can do this, and both the date-values and price-values get new formatting
4. verify that you get a graph-visualization of the data (it will complain that data-outside-time-range, that's ok), click on zoom-to-data and verify you see the graph.