### PR TITLE
introduce standard admonitions on docs pages, with links to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # CSV data source for Grafana
 
 > [!CAUTION]
-> This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead
+> This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+
+## Legacy Information
 
 The Grafana CSV Datasource plugin is designed to load CSV data into Grafana, expanding your capabilities to visualize and analyze data stored in CSV (Comma-Separated Values) format. Whether you have log files, historical data, or other datasets in CSV format, this plugin streamlines the process of integrating this data into your Grafana dashboards.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CSV data source for Grafana
 
 > [!CAUTION]
-> This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+> This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
 
 ## Legacy Information
 

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,7 +14,8 @@ weight: 100
 ---
 
 {{< admonition type="warning" >}}
-This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started
+quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
 {{< /admonition >}}
 
 The CSV data source is an open source plugin for Grafana that lets you visualize data from any URL that returns CSV data, such as REST APIs or static file servers. You can even load data from a local file path.

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,7 +14,7 @@ weight: 100
 ---
 
 {{< admonition type="warning" >}}
-This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started
 quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
 {{< /admonition >}}
 

--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -14,7 +14,7 @@ weight: 600
 ---
 
 {{< admonition type="warning" >}}
-This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started
 quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
 {{< /admonition >}}
 

--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -13,6 +13,11 @@ labels:
 weight: 600
 ---
 
+{{< admonition type="warning" >}}
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started
+quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+{{< /admonition >}}
+
 [Annotations](https://grafana.com/docs/grafana/latest/dashboards/annotations) let you extract data from a data source and use it to annotate a dashboard.
 
 To use the CSV data source for annotations, follow the instructions on [Querying other data sources](https://grafana.com/docs/grafana/latest/dashboards/annotations/#querying-other-data-sources). Make sure to select the CSV from the list of data sources.

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -13,6 +13,11 @@ labels:
 weight: 300
 ---
 
+{{< admonition type="warning" >}}
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started
+quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+{{< /admonition >}}
+
 ## Add a CSV data source
 
 1. In the side menu, click the **Configuration** tab (cog icon)

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -14,7 +14,7 @@ weight: 300
 ---
 
 {{< admonition type="warning" >}}
-This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started
 quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
 {{< /admonition >}}
 

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -14,7 +14,7 @@ weight: 200
 ---
 
 {{< admonition type="warning" >}}
-This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started
 quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
 {{< /admonition >}}
 

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -13,6 +13,11 @@ labels:
 weight: 200
 ---
 
+{{< admonition type="warning" >}}
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started
+quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+{{< /admonition >}}
+
 You can install the CSV plugin using [grafana-cli](https://grafana.com/docs/grafana/latest/administration/cli/), or by downloading the plugin manually.
 
 ## Install using grafana-cli

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -14,7 +14,7 @@ weight: 400
 ---
 
 {{< admonition type="warning" >}}
-This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started
 quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
 {{< /admonition >}}
 

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -13,6 +13,11 @@ labels:
 weight: 400
 ---
 
+{{< admonition type="warning" >}}
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started
+quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+{{< /admonition >}}
+
 This page explains what each part of the query editor does, and how you can configure it.
 
 The query editor for the CSV data source consists of a number of tabs. Each tab configures a part of the query.

--- a/docs/sources/variables.md
+++ b/docs/sources/variables.md
@@ -13,6 +13,11 @@ labels:
 weight: 500
 ---
 
+{{< admonition type="warning" >}}
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started
+quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+{{< /admonition >}}
+
 [Query variables](https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable) let you extract data from a data source and use it to populate a dashboard variable.
 
 To query the CSV data source for variables, follow the instructions on how to [Add a query variable](https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable). Make sure to select the CSV from the list of data sources.

--- a/docs/sources/variables.md
+++ b/docs/sources/variables.md
@@ -14,7 +14,7 @@ weight: 500
 ---
 
 {{< admonition type="warning" >}}
-This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.  If you want to get started
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started
 quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
 {{< /admonition >}}
 


### PR DESCRIPTION
The CSV plugin, while deprecated, is a big problem in our overall docs because it's got extreme Google SEO juice.  Google "Grafana CSV" and you'll land here.  In cloud data, we see a substantial number of people try & fail down this route.  To that end, we wrote a simple blog post that tells people where to go the right way (use Infinity as we know).

In Grafana web data, we see CSV plugins docs still getting substantial traffic.  This PR simply updates the admonition in the docs to point to a clean set of instructions/examples on "how to do CSV right", and then copies the admonition onto the docs pages.  The goal is to gradually redirect users away from this approach over time, and towards the infinity approach.