### PR TITLE
introduce standard admonitions on docs pages, with links to quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # CSV data source for Grafana
 
 > [!CAUTION]
-> This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead
+> This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+
+## Legacy Information
 
 The Grafana CSV Datasource plugin is designed to load CSV data into Grafana, expanding your capabilities to visualize and analyze data stored in CSV (Comma-Separated Values) format. Whether you have log files, historical data, or other datasets in CSV format, this plugin streamlines the process of integrating this data into your Grafana dashboards.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!CAUTION]
 > This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
 
-## Legacy Information
+## Legacy information
 
 The Grafana CSV Datasource plugin is designed to load CSV data into Grafana, expanding your capabilities to visualize and analyze data stored in CSV (Comma-Separated Values) format. Whether you have log files, historical data, or other datasets in CSV format, this plugin streamlines the process of integrating this data into your Grafana dashboards.
 

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,7 +14,8 @@ weight: 100
 ---
 
 {{< admonition type="warning" >}}
-This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started
+quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
 {{< /admonition >}}
 
 The CSV data source is an open source plugin for Grafana that lets you visualize data from any URL that returns CSV data, such as REST APIs or static file servers. You can even load data from a local file path.

--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -13,6 +13,11 @@ labels:
 weight: 600
 ---
 
+{{< admonition type="warning" >}}
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started
+quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+{{< /admonition >}}
+
 [Annotations](https://grafana.com/docs/grafana/latest/dashboards/annotations) let you extract data from a data source and use it to annotate a dashboard.
 
 To use the CSV data source for annotations, follow the instructions on [Querying other data sources](https://grafana.com/docs/grafana/latest/dashboards/annotations/#querying-other-data-sources). Make sure to select the CSV from the list of data sources.

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -13,6 +13,11 @@ labels:
 weight: 300
 ---
 
+{{< admonition type="warning" >}}
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started
+quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+{{< /admonition >}}
+
 ## Add a CSV data source
 
 1. In the side menu, click the **Configuration** tab (cog icon)

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -13,6 +13,11 @@ labels:
 weight: 200
 ---
 
+{{< admonition type="warning" >}}
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started
+quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+{{< /admonition >}}
+
 You can install the CSV plugin using [grafana-cli](https://grafana.com/docs/grafana/latest/administration/cli/), or by downloading the plugin manually.
 
 ## Install using grafana-cli

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -13,6 +13,11 @@ labels:
 weight: 400
 ---
 
+{{< admonition type="warning" >}}
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started
+quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+{{< /admonition >}}
+
 This page explains what each part of the query editor does, and how you can configure it.
 
 The query editor for the CSV data source consists of a number of tabs. Each tab configures a part of the query.

--- a/docs/sources/variables.md
+++ b/docs/sources/variables.md
@@ -13,6 +13,11 @@ labels:
 weight: 500
 ---
 
+{{< admonition type="warning" >}}
+This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. If you want to get started
+quickly with CSV and Grafana, please read [How to Visualize CSV Data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/), which uses the recommended approach.
+{{< /admonition >}}
+
 [Query variables](https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable) let you extract data from a data source and use it to populate a dashboard variable.
 
 To query the CSV data source for variables, follow the instructions on how to [Add a query variable](https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable). Make sure to select the CSV from the list of data sources.


### PR DESCRIPTION
https://github.com/grafana/grafana-csv-datasource/pull/335 is stuck on following issue and I don't know easy way to make gihub action sign cla. So this was faster - just to recreate the PR. 

<img width="961" alt="image" src="https://github.com/user-attachments/assets/b7f47e89-0996-4ac9-81d1-7dd92d9273bc" />
