### PR TITLE
Fix: removes props mutations

### DIFF
--- a/.changeset/fresh-kangaroos-fetch.md
+++ b/.changeset/fresh-kangaroos-fetch.md
@@ -1,0 +1,5 @@
+---
+'grafana-csv-datasource': patch
+---
+
+Chore: Remove props mutations

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -12,7 +12,7 @@ import {
 } from '@grafana/experimental';
 import { css } from '@emotion/css';
 import { Divider } from 'components/Divider';
-import { getOptionsWithDefaults } from 'utils';
+import { getOptionsWithDefaults } from './utils';
 
 interface Props extends DataSourcePluginOptionsEditorProps<CSVDataSourceOptions> {}
 

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -1,8 +1,7 @@
 import { DataSourcePluginOptionsEditorProps, GrafanaTheme2 } from '@grafana/data';
 import { Field, Input, RadioButtonGroup, useStyles2 } from '@grafana/ui';
-import defaults from 'lodash/defaults';
 import React, { ChangeEvent } from 'react';
-import { CSVDataSourceOptions, defaultOptions } from './types';
+import { CSVDataSourceOptions } from './types';
 import {
   AdvancedHttpSettings,
   Auth,
@@ -13,6 +12,7 @@ import {
 } from '@grafana/experimental';
 import { css } from '@emotion/css';
 import { Divider } from 'components/Divider';
+import { getOptionsWithDefaults } from 'utils';
 
 interface Props extends DataSourcePluginOptionsEditorProps<CSVDataSourceOptions> {}
 
@@ -20,15 +20,16 @@ interface Props extends DataSourcePluginOptionsEditorProps<CSVDataSourceOptions>
  * ConfigEditor lets the user configure connection details like the URL or
  * authentication.
  */
-export const ConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
-  const jsonData = defaults(options.jsonData, defaultOptions);
+export const ConfigEditor: React.FC<Props> = (props) => {
+  const { onOptionsChange } = props;
+  const optionsWithDefaults = getOptionsWithDefaults(props.options);
   const styles = useStyles2(getStyles);
 
   const onParamsChange = (e: ChangeEvent<HTMLInputElement>) => {
     onOptionsChange({
-      ...options,
+      ...optionsWithDefaults,
       jsonData: {
-        ...jsonData,
+        ...optionsWithDefaults.jsonData,
         queryParams: e.currentTarget.value,
       },
     });
@@ -36,9 +37,9 @@ export const ConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
 
   const onStorageChange = (value?: string) => {
     onOptionsChange({
-      ...options,
+      ...optionsWithDefaults,
       jsonData: {
-        ...jsonData,
+        ...optionsWithDefaults.jsonData,
         storage: value!,
       },
     });
@@ -46,7 +47,7 @@ export const ConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
 
   const onLocalPathChange = (e: ChangeEvent<HTMLInputElement>) => {
     onOptionsChange({
-      ...options,
+      ...optionsWithDefaults,
       url: e.currentTarget.value,
     });
   };
@@ -67,22 +68,26 @@ export const ConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
             { label: 'HTTP', value: 'http' },
             { label: 'Local', value: 'local' },
           ]}
-          value={jsonData.storage}
+          value={optionsWithDefaults.jsonData.storage}
           onChange={onStorageChange}
         />
       </Field>
 
       <Divider />
 
-      {jsonData.storage === 'http' ? (
+      {optionsWithDefaults.jsonData.storage === 'http' ? (
         <>
-          <ConnectionSettings config={options} onChange={onOptionsChange} urlPlaceholder="http://localhost:8080" />
+          <ConnectionSettings
+            config={optionsWithDefaults}
+            onChange={onOptionsChange}
+            urlPlaceholder="http://localhost:8080"
+          />
 
           <Divider />
 
           <Auth
             {...convertLegacyAuthProps({
-              config: options,
+              config: optionsWithDefaults,
               onChange: onOptionsChange,
             })}
           />
@@ -90,14 +95,14 @@ export const ConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
           <Divider />
 
           <ConfigSection title="Additional settings" isCollapsible>
-            <AdvancedHttpSettings config={options} onChange={onOptionsChange} />
+            <AdvancedHttpSettings config={optionsWithDefaults} onChange={onOptionsChange} />
 
             <div className={styles.space} />
 
             <Field label="Custom query parameters" description="Add custom parameters to your queries.">
               <Input
                 width={40}
-                value={jsonData.queryParams}
+                value={optionsWithDefaults.jsonData.queryParams}
                 onChange={onParamsChange}
                 spellCheck={false}
                 placeholder="limit=100"
@@ -107,10 +112,10 @@ export const ConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
         </>
       ) : null}
 
-      {jsonData.storage === 'local' ? (
+      {optionsWithDefaults.jsonData.storage === 'local' ? (
         <Field label="Path">
           <Input
-            value={options.url}
+            value={optionsWithDefaults.url}
             onChange={onLocalPathChange}
             spellCheck={false}
             width={40}

--- a/src/components/FieldEditor.tsx
+++ b/src/components/FieldEditor.tsx
@@ -4,7 +4,7 @@ import React, { FormEvent, useState } from 'react';
 import { CSVQuery, FieldSchema } from '../types';
 import { SchemaEditor } from './SchemaEditor';
 import momentTz from 'moment-timezone';
-import { getQueryWithDefaults } from 'utils';
+import { getQueryWithDefaults } from '../utils';
 
 interface Props {
   query: CSVQuery;

--- a/src/components/FieldEditor.tsx
+++ b/src/components/FieldEditor.tsx
@@ -1,10 +1,10 @@
 import { SelectableValue } from '@grafana/data';
 import { InlineField, InlineFieldRow, InlineSwitch, Input, Select, Switch } from '@grafana/ui';
-import defaults from 'lodash/defaults';
 import React, { FormEvent, useState } from 'react';
-import { CSVQuery, defaultQuery, FieldSchema } from '../types';
+import { CSVQuery, FieldSchema } from '../types';
 import { SchemaEditor } from './SchemaEditor';
 import momentTz from 'moment-timezone';
+import { getQueryWithDefaults } from 'utils';
 
 interface Props {
   query: CSVQuery;
@@ -15,10 +15,8 @@ interface Props {
 }
 
 export const FieldEditor = ({ query, onChange, onRunQuery, limit, editorContext }: Props) => {
-  const { header, skipRows, delimiter, decimalSeparator, ignoreUnknown, schema, timezone } = defaults(
-    query,
-    defaultQuery
-  );
+  const { header, skipRows, delimiter, decimalSeparator, ignoreUnknown, schema, timezone } =
+    getQueryWithDefaults(query);
 
   const [numSkipRows, setNumSkipRows] = useState(skipRows?.toString());
 

--- a/src/components/TabbedQueryEditor.tsx
+++ b/src/components/TabbedQueryEditor.tsx
@@ -2,12 +2,12 @@ import { css } from '@emotion/css';
 import { TimeRange } from '@grafana/data';
 import { CodeEditor, InfoBox, InlineField, InlineFieldRow, Input, RadioButtonGroup, useTheme } from '@grafana/ui';
 import { DataSource } from 'datasource';
-import defaults from 'lodash/defaults';
 import React, { useState } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { CSVQuery, Pair, defaultQuery } from '../types';
+import { CSVQuery, Pair } from '../types';
 import { KeyValueEditor } from './KeyValueEditor';
 import { PathEditor } from './PathEditor';
+import { getQueryWithDefaults } from 'utils';
 
 // Display a warning message when user adds any of the following headers.
 const sensitiveHeaders = ['authorization', 'proxy-authorization', 'x-api-key'];
@@ -29,7 +29,7 @@ export const TabbedQueryEditor = ({ query, onChange, onRunQuery, fieldsTab, expe
   const [tabIndex, setTabIndex] = useState(0);
   const theme = useTheme();
 
-  const q = defaults(query, defaultQuery);
+  const q = getQueryWithDefaults(query);
 
   const onBodyChange = (body: string) => {
     onChange({ ...q, body });

--- a/src/components/TabbedQueryEditor.tsx
+++ b/src/components/TabbedQueryEditor.tsx
@@ -7,7 +7,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { CSVQuery, Pair } from '../types';
 import { KeyValueEditor } from './KeyValueEditor';
 import { PathEditor } from './PathEditor';
-import { getQueryWithDefaults } from 'utils';
+import { getQueryWithDefaults } from '../utils';
 
 // Display a warning message when user adds any of the following headers.
 const sensitiveHeaders = ['authorization', 'proxy-authorization', 'x-api-key'];

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,10 @@ export interface CSVQuery extends DataQuery {
   };
 }
 
-export const defaultQuery: Partial<CSVQuery> = {
+export const defaultQuery: Pick<
+  CSVQuery,
+  'delimiter' | 'decimalSeparator' | 'header' | 'ignoreUnknown' | 'skipRows' | 'schema'
+> = {
   delimiter: ',',
   decimalSeparator: '.',
   header: true,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,158 @@
+import { DataSourceSettings } from '@grafana/data';
+
+import { getOptionsWithDefaults, getQueryWithDefaults } from './utils';
+import { CSVDataSourceOptions, CSVQuery } from './types';
+
+describe('utils', () => {
+  describe('getOptionsWithDefaults', () => {
+    const BLANK_OPTIONS: DataSourceSettings<CSVDataSourceOptions> = {
+      access: '',
+      basicAuth: false,
+      basicAuthUser: '',
+      id: -1,
+      isDefault: false,
+      jsonData: {},
+      name: '',
+      orgId: -1,
+      readOnly: false,
+      secureJsonFields: {},
+      type: '',
+      typeLogoUrl: '',
+      typeName: '',
+      uid: '',
+      url: '',
+      user: '',
+      database: '',
+      withCredentials: false,
+    };
+
+    it('should return options unchanged when storage is already set', () => {
+      const options = { ...BLANK_OPTIONS, jsonData: { storage: 'local' } };
+
+      const result = getOptionsWithDefaults(options);
+
+      expect(result).toBe(options);
+      expect(result.jsonData.storage).toBe('local');
+    });
+
+    it('should add default options when storage is not set', () => {
+      const options = { ...BLANK_OPTIONS, jsonData: {} };
+
+      const result = getOptionsWithDefaults(options);
+
+      expect(result.jsonData.storage).toBe('http');
+    });
+
+    it('should preserve existing jsonData properties when storage is already set', () => {
+      const options = { ...BLANK_OPTIONS, jsonData: { storage: 'local', queryParams: 'test=value' } };
+
+      const result = getOptionsWithDefaults(options);
+
+      expect(result.jsonData.storage).toBe('local');
+      expect(result.jsonData.queryParams).toBe('test=value');
+    });
+
+    it('should preserve existing jsonData when adding defaults', () => {
+      const options = { ...BLANK_OPTIONS, jsonData: { queryParams: 'test=value' } };
+
+      const result = getOptionsWithDefaults(options);
+
+      expect(result.jsonData.storage).toBe('http');
+      expect(result.jsonData.queryParams).toBe('test=value');
+    });
+  });
+
+  describe('getQueryWithDefaults', () => {
+    const createBaseQuery = (): CSVQuery => ({
+      refId: 'A',
+      delimiter: ',',
+      schema: [],
+      header: true,
+      ignoreUnknown: false,
+      skipRows: 0,
+      timezone: 'UTC',
+      decimalSeparator: '.',
+      method: 'GET',
+      path: '',
+      queryParams: '',
+      params: [],
+      headers: [],
+      body: '',
+      experimental: {
+        regex: false,
+      },
+    });
+
+    it('should return query with all defaults when no properties are set', () => {
+      const query: any = createBaseQuery();
+      delete query.delimiter;
+      delete query.decimalSeparator;
+      delete query.header;
+      delete query.ignoreUnknown;
+      delete query.skipRows;
+      delete query.schema;
+
+      const result = getQueryWithDefaults(query);
+
+      expect(result.delimiter).toBe(',');
+      expect(result.decimalSeparator).toBe('.');
+      expect(result.header).toBe(true);
+      expect(result.ignoreUnknown).toBe(false);
+      expect(result.skipRows).toBe(0);
+      expect(result.schema).toEqual([]);
+    });
+
+    it('should preserve set values and only use defaults for undefined properties', () => {
+      const query = createBaseQuery();
+      query.delimiter = ';';
+      query.header = false;
+      query.skipRows = 5;
+      query.schema = [{ name: 'test', type: 'string' }];
+
+      const result = getQueryWithDefaults(query);
+
+      expect(result.delimiter).toBe(';');
+      expect(result.decimalSeparator).toBe('.');
+      expect(result.header).toBe(false);
+      expect(result.ignoreUnknown).toBe(false);
+      expect(result.skipRows).toBe(5);
+      expect(result.schema).toEqual([{ name: 'test', type: 'string' }]);
+    });
+
+    it('should preserve falsy values (empty string, 0, false)', () => {
+      const query = createBaseQuery();
+      query.delimiter = '';
+      query.decimalSeparator = '';
+      query.header = false;
+      query.ignoreUnknown = false;
+      query.skipRows = 0;
+      query.schema = [];
+
+      const result = getQueryWithDefaults(query);
+
+      expect(result.delimiter).toBe('');
+      expect(result.decimalSeparator).toBe('');
+      expect(result.header).toBe(false);
+      expect(result.ignoreUnknown).toBe(false);
+      expect(result.skipRows).toBe(0);
+      expect(result.schema).toEqual([]);
+    });
+
+    it('should preserve other query properties', () => {
+      const query = createBaseQuery();
+      query.refId = 'B';
+      query.method = 'POST';
+      query.path = '/test.csv';
+      query.timezone = 'America/New_York';
+      query.experimental.regex = true;
+
+      const result = getQueryWithDefaults(query);
+
+      expect(result.refId).toBe('B');
+      expect(result.method).toBe('POST');
+      expect(result.path).toBe('/test.csv');
+      expect(result.timezone).toBe('America/New_York');
+      expect(result.experimental.regex).toBe(true);
+    });
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,20 @@
+import { DataSourceSettings } from '@grafana/data';
+import { CSVDataSourceOptions, CSVQuery, defaultOptions, defaultQuery } from 'types';
+
+export const getOptionsWithDefaults = (options: DataSourceSettings<CSVDataSourceOptions, {}>) => {
+  if (options.jsonData.storage) {
+    return options;
+  }
+
+  return { ...options, jsonData: { ...options.jsonData, ...defaultOptions } };
+};
+
+export const getQueryWithDefaults = (query: CSVQuery): CSVQuery => ({
+  ...query,
+  delimiter: query.delimiter ?? defaultQuery.delimiter,
+  decimalSeparator: query.decimalSeparator ?? defaultQuery.decimalSeparator,
+  header: query.header ?? defaultQuery.header,
+  ignoreUnknown: query.ignoreUnknown ?? defaultQuery.ignoreUnknown,
+  skipRows: query.skipRows ?? defaultQuery.skipRows,
+  schema: query.schema ?? defaultQuery.schema,
+});


### PR DESCRIPTION
We are currently monitoring when data sources mutate props and found our way to this repo because of https://ops.grafana-ops.net/goto/mPuEDVPNg?orgId=1. These fixes should remove any props mutation. I've tested this to the best of my abilities but I'm no expert on this data source so I could use help testing this so we keep the previous behavior.

https://lodash.info/doc/defaults
![image](https://github.com/user-attachments/assets/7c49262e-2944-4b57-9294-4ec2acc0c1b9)