### PR TITLE
docs: mark plugin deprecated, support ends February 1, 2027

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CSV data source for Grafana
 
 > [!WARNING]
-> Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+> This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 
 ## Legacy information
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CSV data source for Grafana
 
 > [!WARNING]
-> This plugin is in maintenance mode. It won't receive new features, and bug fixes aren't guaranteed. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+> This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 
 ## Legacy information
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CSV data source for Grafana
 
 > [!WARNING]
-> This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+> This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 
 ## Legacy information
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CSV data source for Grafana
 
 > [!WARNING]
-> This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+> Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 
 ## Legacy information
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CSV data source for Grafana
 
 > [!WARNING]
-> This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+> This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 
 ## Legacy information
 

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,7 +14,7 @@ weight: 100
 ---
 
 {{< admonition type="warning" >}}
-This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 The CSV data source is an open source plugin for Grafana that lets you visualize data from any URL that returns CSV data, such as REST APIs or static file servers. You can even load data from a local file path.

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,7 +14,7 @@ weight: 100
 ---
 
 {{< admonition type="warning" >}}
-This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 The CSV data source is an open source plugin for Grafana that lets you visualize data from any URL that returns CSV data, such as REST APIs or static file servers. You can even load data from a local file path.

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,7 +14,7 @@ weight: 100
 ---
 
 {{< admonition type="warning" >}}
-This plugin is in maintenance mode. It won't receive new features, and bug fixes aren't guaranteed. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 The CSV data source is an open source plugin for Grafana that lets you visualize data from any URL that returns CSV data, such as REST APIs or static file servers. You can even load data from a local file path.

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,7 +14,7 @@ weight: 100
 ---
 
 {{< admonition type="warning" >}}
-This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 The CSV data source is an open source plugin for Grafana that lets you visualize data from any URL that returns CSV data, such as REST APIs or static file servers. You can even load data from a local file path.

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,7 +14,7 @@ weight: 100
 ---
 
 {{< admonition type="warning" >}}
-Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 The CSV data source is an open source plugin for Grafana that lets you visualize data from any URL that returns CSV data, such as REST APIs or static file servers. You can even load data from a local file path.

--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -14,7 +14,7 @@ weight: 600
 ---
 
 {{< admonition type="warning" >}}
-This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 [Annotations](https://grafana.com/docs/grafana/latest/dashboards/annotations) let you extract data from a data source and use it to annotate a dashboard.

--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -14,7 +14,7 @@ weight: 600
 ---
 
 {{< admonition type="warning" >}}
-This plugin is in maintenance mode. It won't receive new features, and bug fixes aren't guaranteed. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 [Annotations](https://grafana.com/docs/grafana/latest/dashboards/annotations) let you extract data from a data source and use it to annotate a dashboard.

--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -14,7 +14,7 @@ weight: 600
 ---
 
 {{< admonition type="warning" >}}
-Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 [Annotations](https://grafana.com/docs/grafana/latest/dashboards/annotations) let you extract data from a data source and use it to annotate a dashboard.

--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -14,7 +14,7 @@ weight: 600
 ---
 
 {{< admonition type="warning" >}}
-This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 [Annotations](https://grafana.com/docs/grafana/latest/dashboards/annotations) let you extract data from a data source and use it to annotate a dashboard.

--- a/docs/sources/annotations.md
+++ b/docs/sources/annotations.md
@@ -14,7 +14,7 @@ weight: 600
 ---
 
 {{< admonition type="warning" >}}
-This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 [Annotations](https://grafana.com/docs/grafana/latest/dashboards/annotations) let you extract data from a data source and use it to annotate a dashboard.

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -14,7 +14,7 @@ weight: 300
 ---
 
 {{< admonition type="warning" >}}
-This plugin is in maintenance mode. It won't receive new features, and bug fixes aren't guaranteed. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 ## Add a CSV data source

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -14,7 +14,7 @@ weight: 300
 ---
 
 {{< admonition type="warning" >}}
-This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 ## Add a CSV data source

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -14,7 +14,7 @@ weight: 300
 ---
 
 {{< admonition type="warning" >}}
-This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 ## Add a CSV data source

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -14,7 +14,7 @@ weight: 300
 ---
 
 {{< admonition type="warning" >}}
-This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 ## Add a CSV data source

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -14,7 +14,7 @@ weight: 300
 ---
 
 {{< admonition type="warning" >}}
-Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 ## Add a CSV data source

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -14,7 +14,7 @@ weight: 200
 ---
 
 {{< admonition type="warning" >}}
-This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 You can install the CSV plugin using [grafana-cli](https://grafana.com/docs/grafana/latest/administration/cli/), or by downloading the plugin manually.

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -14,7 +14,7 @@ weight: 200
 ---
 
 {{< admonition type="warning" >}}
-This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 You can install the CSV plugin using [grafana-cli](https://grafana.com/docs/grafana/latest/administration/cli/), or by downloading the plugin manually.

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -14,7 +14,7 @@ weight: 200
 ---
 
 {{< admonition type="warning" >}}
-This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 You can install the CSV plugin using [grafana-cli](https://grafana.com/docs/grafana/latest/administration/cli/), or by downloading the plugin manually.

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -14,7 +14,7 @@ weight: 200
 ---
 
 {{< admonition type="warning" >}}
-This plugin is in maintenance mode. It won't receive new features, and bug fixes aren't guaranteed. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 You can install the CSV plugin using [grafana-cli](https://grafana.com/docs/grafana/latest/administration/cli/), or by downloading the plugin manually.

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -14,7 +14,7 @@ weight: 200
 ---
 
 {{< admonition type="warning" >}}
-Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 You can install the CSV plugin using [grafana-cli](https://grafana.com/docs/grafana/latest/administration/cli/), or by downloading the plugin manually.

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -14,7 +14,7 @@ weight: 400
 ---
 
 {{< admonition type="warning" >}}
-This plugin is in maintenance mode. It won't receive new features, and bug fixes aren't guaranteed. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 This page explains what each part of the query editor does, and how you can configure it.

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -14,7 +14,7 @@ weight: 400
 ---
 
 {{< admonition type="warning" >}}
-This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 This page explains what each part of the query editor does, and how you can configure it.

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -14,7 +14,7 @@ weight: 400
 ---
 
 {{< admonition type="warning" >}}
-Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 This page explains what each part of the query editor does, and how you can configure it.

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -14,7 +14,7 @@ weight: 400
 ---
 
 {{< admonition type="warning" >}}
-This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 This page explains what each part of the query editor does, and how you can configure it.

--- a/docs/sources/query-editor.md
+++ b/docs/sources/query-editor.md
@@ -14,7 +14,7 @@ weight: 400
 ---
 
 {{< admonition type="warning" >}}
-This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 This page explains what each part of the query editor does, and how you can configure it.

--- a/docs/sources/variables.md
+++ b/docs/sources/variables.md
@@ -14,7 +14,7 @@ weight: 500
 ---
 
 {{< admonition type="warning" >}}
-Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 [Query variables](https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable) let you extract data from a data source and use it to populate a dashboard variable.

--- a/docs/sources/variables.md
+++ b/docs/sources/variables.md
@@ -14,7 +14,7 @@ weight: 500
 ---
 
 {{< admonition type="warning" >}}
-This plugin is in maintenance mode. It won't receive new features, and bug fixes aren't guaranteed. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 [Query variables](https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable) let you extract data from a data source and use it to populate a dashboard variable.

--- a/docs/sources/variables.md
+++ b/docs/sources/variables.md
@@ -14,7 +14,7 @@ weight: 500
 ---
 
 {{< admonition type="warning" >}}
-This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 [Query variables](https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable) let you extract data from a data source and use it to populate a dashboard variable.

--- a/docs/sources/variables.md
+++ b/docs/sources/variables.md
@@ -14,7 +14,7 @@ weight: 500
 ---
 
 {{< admonition type="warning" >}}
-This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 [Query variables](https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable) let you extract data from a data source and use it to populate a dashboard variable.

--- a/docs/sources/variables.md
+++ b/docs/sources/variables.md
@@ -14,7 +14,7 @@ weight: 500
 ---
 
 {{< admonition type="warning" >}}
-This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 {{< /admonition >}}
 
 [Query variables](https://grafana.com/docs/grafana/latest/variables/variable-types/add-query-variable) let you extract data from a data source and use it to populate a dashboard variable.

--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,7 @@
 # CSV data source for Grafana
 
 > [!WARNING]
-> This plugin is in maintenance mode. It won't receive new features, and bug fixes aren't guaranteed. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+> This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 
 The Grafana CSV Datasource plugin is designed to load CSV data into Grafana, expanding your capabilities to visualize and analyze data stored in CSV (Comma-Separated Values) format. Whether you have log files, historical data, or other datasets in CSV format, this plugin streamlines the process of integrating this data into your Grafana dashboards.
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,7 @@
 # CSV data source for Grafana
 
 > [!WARNING]
-> This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+> This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 
 The Grafana CSV Datasource plugin is designed to load CSV data into Grafana, expanding your capabilities to visualize and analyze data stored in CSV (Comma-Separated Values) format. Whether you have log files, historical data, or other datasets in CSV format, this plugin streamlines the process of integrating this data into your Grafana dashboards.
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,7 @@
 # CSV data source for Grafana
 
 > [!WARNING]
-> Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+> This plugin will be deprecated on February 1, 2027. Until then, it will only receive critical security updates. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 
 The Grafana CSV Datasource plugin is designed to load CSV data into Grafana, expanding your capabilities to visualize and analyze data stored in CSV (Comma-Separated Values) format. Whether you have log files, historical data, or other datasets in CSV format, this plugin streamlines the process of integrating this data into your Grafana dashboards.
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,7 @@
 # CSV data source for Grafana
 
 > [!WARNING]
-> This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+> Starting on February 1, 2027, this plugin will be deprecated. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 
 The Grafana CSV Datasource plugin is designed to load CSV data into Grafana, expanding your capabilities to visualize and analyze data stored in CSV (Comma-Separated Values) format. Whether you have log files, historical data, or other datasets in CSV format, this plugin streamlines the process of integrating this data into your Grafana dashboards.
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,7 @@
 # CSV data source for Grafana
 
 > [!WARNING]
-> This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
+> This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).
 
 The Grafana CSV Datasource plugin is designed to load CSV data into Grafana, expanding your capabilities to visualize and analyze data stored in CSV (Comma-Separated Values) format. Whether you have log files, historical data, or other datasets in CSV format, this plugin streamlines the process of integrating this data into your Grafana dashboards.
 


### PR DESCRIPTION
**What**
Updates the plugin notice from the previous "maintenance mode" wording to a deprecation notice with a defined end-of-support date.

### New banner text:

This plugin is deprecated and will only receive critical security updates. Support will end on February 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead. To get started quickly with CSV data in Grafana, refer to [How to visualize CSV data with Grafana](https://grafana.com/blog/2025/02/05/how-to-visualize-csv-data-with-grafana/).

**Why**
Communicates the deprecation timeline clearly to users so they can plan a migration to the Infinity data source ahead of the February 1, 2027 end-of-support date.

**Where it shows up**
The banner appears in both user-facing surfaces, so both sources were updated:

Docs site (grafana.com/docs/plugins/marcusolsson-csv-datasource/) — all 6 pages under docs/sources/:
_index.md, annotations.md, configuration.md, installation.md, variables.md, query-editor.md
Plugin catalog page (grafana.com/grafana/plugins/marcusolsson-csv-datasource/):
src/README.md (rendered on the catalog) and root README.md (kept in sync)